### PR TITLE
Rename compile functions in CGPGraph class

### DIFF
--- a/gp/cgp_graph.py
+++ b/gp/cgp_graph.py
@@ -174,7 +174,7 @@ class CGPGraph():
             for node in active_nodes[hidden_column_idx]:
                 node.format_output_str(self)
 
-    def compile_func(self):
+    def to_func(self):
 
         self._format_output_str_of_all_nodes()
 
@@ -182,10 +182,7 @@ class CGPGraph():
         exec(func_str)
         return locals()['_f']
 
-    def to_func(self):
-        return self.compile_func()
-
-    def compile_torch_class(self):
+    def to_torch(self):
 
         for i, node in enumerate(self.input_nodes):
             node.format_output_str_torch(self)
@@ -224,9 +221,6 @@ class _C(torch.nn.Module):
 
         return locals()['_c']
 
-    def to_torch(self):
-        return self.compile_torch_class()
-
     def update_parameters_from_torch_class(self, torch_cls):
         for n in self._nodes:
             if n.is_parameter:
@@ -235,7 +229,7 @@ class _C(torch.nn.Module):
                 except AttributeError:
                     pass
 
-    def compile_sympy_expr(self, simplify=True):
+    def to_sympy(self, simplify=True):
 
         self._format_output_str_of_all_nodes()
 
@@ -259,9 +253,6 @@ class _C(torch.nn.Module):
             for i, expr in enumerate(sympy_exprs):
                 sympy_exprs[i] = self._validate_sympy_expr(expr.simplify())
             return sympy_exprs
-
-    def to_sympy(self, simplify=True):
-        return self.compile_sympy_expr(simplify)
 
     def _validate_sympy_expr(self, expr):
 

--- a/test/test_cgp_evolve.py
+++ b/test/test_cgp_evolve.py
@@ -20,7 +20,7 @@ def objective_parallel_cgp_population(individual):
     n_function_evaluations = 100
 
     graph = gp.CGPGraph(individual.genome)
-    f_graph = graph.compile_torch_class()
+    f_graph = graph.to_torch()
 
     def f_target(x):  # target function
         return 1. + x[:, 0] - x[:, 1]

--- a/test/test_cgp_graph.py
+++ b/test/test_cgp_graph.py
@@ -34,13 +34,13 @@ def test_direct_input_output():
     assert abs(x[0] - y[0]) < 1e-15
 
 
-def test_compile_simple():
+def test_to_func_simple():
     primitives = [gp.CGPAdd]
     genome = gp.CGPGenome(2, 1, 1, 1, 1, primitives)
 
     genome.dna = [-1, None, None, -1, None, None, 0, 0, 1, -2, 2, None]
     graph = gp.CGPGraph(genome)
-    f = graph.compile_func()
+    f = graph.to_func()
 
     x = [5., 2.]
     y = f(x)
@@ -52,7 +52,7 @@ def test_compile_simple():
 
     genome.dna = [-1, None, None, -1, None, None, 0, 0, 1, -2, 2, None]
     graph = gp.CGPGraph(genome)
-    f = graph.compile_func()
+    f = graph.to_func()
 
     x = [5., 2.]
     y = f(x)
@@ -66,7 +66,7 @@ def test_compile_two_columns():
 
     genome.dna = [-1, None, None, -1, None, None, 0, 0, 1, 1, 0, 2, -2, 3, None]
     graph = gp.CGPGraph(genome)
-    f = graph.compile_func()
+    f = graph.to_func()
 
     x = [5., 2.]
     y = f(x)
@@ -80,7 +80,7 @@ def test_compile_two_columns_two_rows():
 
     genome.dna = [-1, None, None, -1, None, None, 0, 0, 1, 1, 0, 1, 0, 0, 2, 0, 2, 3, -2, 4, None, -2, 5, None]
     graph = gp.CGPGraph(genome)
-    f = graph.compile_func()
+    f = graph.to_func()
 
     x = [5., 2.]
     y = f(x)
@@ -106,7 +106,7 @@ def test_compile_addsubmul():
         1, 2, 3, 0, 0, 0,
         -2, 4, None]
     graph = gp.CGPGraph(genome)
-    f = graph.compile_func()
+    f = graph.to_func()
 
     x = [5., 2.]
     y = f(x)
@@ -114,13 +114,13 @@ def test_compile_addsubmul():
     assert(abs(((x[0] * x[1]) - (x[0] - x[1])) - y[0]) < 1e-15)
 
 
-def test_compile_torch_and_backprop():
+def test_to_torch_and_backprop():
     primitives = [gp.CGPMul, gp.CGPConstantFloat]
     genome = gp.CGPGenome(1, 1, 2, 2, 1, primitives)
     genome.dna = [-1, None, None, 1, None, None, 1, None, None, 0, 0, 1, 0, 0, 1, -2, 3, None]
     graph = gp.CGPGraph(genome)
 
-    c = graph.compile_torch_class()
+    c = graph.to_torch()
 
     optimizer = torch.optim.SGD(c.parameters(), lr=1e-1)
     criterion = torch.nn.MSELoss()
@@ -147,7 +147,7 @@ def test_compile_torch_and_backprop():
     assert(abs(c(x_torch)[0].detach().numpy() - graph(x))[0] < 1e-15)
 
 
-def test_compile_sympy_expr():
+def test_to_sympy():
     primitives = [gp.CGPAdd, gp.CGPConstantFloat]
     genome = gp.CGPGenome(1, 1, 2, 2, 1, primitives)
 
@@ -157,7 +157,7 @@ def test_compile_sympy_expr():
     x_0_target, y_0_target = sympy.symbols('x_0_target y_0_target')
     y_0_target = x_0_target + 1.
 
-    y_0 = graph.compile_sympy_expr()[0]
+    y_0 = graph.to_sympy()[0]
 
     for x in np.random.normal(size=100):
         assert abs(y_0_target.subs('x_0_target', x).evalf() - y_0.subs('x_0', x).evalf()) < 1e-12


### PR DESCRIPTION
Renames the `compile_` functions to `to_` and removes the duplicate functions in the `CGPGraph` class. Adapts the tests as well.

This addresses and fixes #13 .