### PR TITLE
Add setup.py to make library installable via pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version='0.1',
     author='Jakob Jordan, Maximilian Schmidt',
     author_email='jakobjordan@posteo.de',
-    description=('Cartesian genetic programming in Python.'),
+    description=('Cartesian Genetic Programming in Python.'),
     license='GPLv3',
     keywords='genetic programming',
     url='https://github.com/jakobj/python-gp',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+# encoding: utf8
+from setuptools import setup
+
+setup(
+    name='cgprog',
+    version='0.1',
+    author='Jakob Jordan, Maximilian Schmidt',
+    author_email='j.jordan@fz-juelich.de',
+    description=('Cartesian genetic programming in Python.'),
+    license='GPLv3',
+    keywords='genetic programming',
+    url='https://github.com/jakobj/python-gp',
+    python_requires='>=3.6, <4',
+    install_requires=['sympy', 'torch', 'numpy', ],
+    packages=['gp', 'gp.ea'],
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Topic :: Utilities',
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='python-gp',
     version='0.1',
     author='Jakob Jordan, Maximilian Schmidt',
-    author_email='j.jordan@fz-juelich.de',
+    author_email='jakobjordan@posteo.de',
     description=('Cartesian genetic programming in Python.'),
     license='GPLv3',
     keywords='genetic programming',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 setup(
-    name='cgprog',
+    name='python-gp',
     version='0.1',
     author='Jakob Jordan, Maximilian Schmidt',
     author_email='j.jordan@fz-juelich.de',


### PR DESCRIPTION
This PR adds a setup script to the repository so that the library can be installed via `pip install .` .
This fixes #7 .