### PR TITLE
Replace all formatted strings by f-strings

### DIFF
--- a/gp/abstract_individual.py
+++ b/gp/abstract_individual.py
@@ -19,7 +19,7 @@ class AbstractIndividual():
         self.idx = None  # an identifier to keep track of all unique genomes
 
     def __repr__(self):
-        return 'Individual(idx={}, fitness={}, genome={}))'.format(self.idx, self.fitness, self.genome)
+        return f'Individual(idx={self.idx}, fitness={self.fitness}, genome={self.genome}))'
 
     def clone(self):
         """Clone the individual.

--- a/gp/cgp_graph.py
+++ b/gp/cgp_graph.py
@@ -179,8 +179,8 @@ class CGPGraph():
     def to_str(self):
 
         self._format_output_str_of_all_nodes()
-
-        return '[{}]'.format(', '.join(node.output_str for node in self.output_nodes))
+        out_str = ', '.join(node.output_str for node in self.output_nodes)
+        return f'[{out_str}]'
 
     def _format_output_str_of_all_nodes(self):
 
@@ -204,8 +204,8 @@ class CGPGraph():
             Callable executing the function represented by the computational graph.
         """
         self._format_output_str_of_all_nodes()
-
-        func_str = 'def _f(x): return [{}]'.format(', '.join(node.output_str for node in self.output_nodes))
+        s = ', '.join(node.output_str for node in self.output_nodes)
+        func_str = f'def _f(x): return [{s}]'
         exec(func_str)
         return locals()['_f']
 
@@ -231,7 +231,7 @@ class CGPGraph():
                 if node.is_parameter:
                     node.format_parameter_str()
                     all_parameter_str.append(node.parameter_str)
-
+        forward_str = ', '.join(node.output_str_torch for node in self.output_nodes)
         class_str = \
 """
 class _C(torch.nn.Module):
@@ -242,14 +242,10 @@ class _C(torch.nn.Module):
         for s in all_parameter_str:
             class_str += '        ' + s
 
-        func_str = \
-"""
+        func_str = f"""
     def forward(self, x):
-        return torch.stack([{}], dim=1)
-"""
-
-        func_str = func_str.format(', '.join(node.output_str_torch for node in self.output_nodes))
-
+        return torch.stack([{forward_str}], dim=1)
+        """
         class_str += func_str
 
         exec(class_str)
@@ -274,7 +270,7 @@ class _C(torch.nn.Module):
         for n in self._nodes:
             if n.is_parameter:
                 try:
-                    n._output = eval('torch_cls._p{}[0]'.format(n._idx))
+                    n._output = eval(f'torch_cls._p{n._idx}[0]')
                 except AttributeError:
                     pass
 

--- a/gp/cgp_node.py
+++ b/gp/cgp_node.py
@@ -64,7 +64,7 @@ class CGPNode():
         return self._idx
 
     def __repr__(self):
-        return '{}(idx: {}, active: {}, arity: {}, inputs {}, output {})'.format(self.__class__.__name__, self._idx, self._active, self._arity, self._inputs, self._output)
+        return f'{self.__class__.__name__}(idx: {self.idx}, active: {self._active}, arity: {self._arity}, inputs {self._inputs}, output {self._outputs})'
 
     def pretty_str(self, n):
         used_characters = 0
@@ -77,7 +77,7 @@ class CGPNode():
         name = self.__class__.__name__[3:]  # cut of "CGP" prefix of class name
         name = name[:n - used_characters]  # cut to correct size
 
-        s = '{:02d}'.format(self._idx)
+        s = f'{self._idx:02d}'
 
         if self._active:
             s += ' * '
@@ -85,7 +85,7 @@ class CGPNode():
             if self._arity > 0:
                 s += '('
                 for i in range(self._arity):
-                    s += '{:02d},'.format(self._inputs[i])
+                    s += f'{self._inputs[i]:02d},'
                 s = s[:-1]
                 s += ')'
                 for i in range(self.max_arity - self._arity):
@@ -159,7 +159,7 @@ class CGPAdd(CGPNode):
         self._output = graph[self._inputs[0]].output + graph[self._inputs[1]].output
 
     def format_output_str(self, graph):
-        self._output_str = '({} + {})'.format(graph[self._inputs[0]].output_str, graph[self._inputs[1]].output_str)
+        self._output_str = f'({graph[self._inputs[0]].output_str} + {graph[self._inputs[1]].output_str})'
 
 
 class CGPSub(CGPNode):
@@ -174,7 +174,7 @@ class CGPSub(CGPNode):
         self._output = graph[self._inputs[0]].output - graph[self._inputs[1]].output
 
     def format_output_str(self, graph):
-        self._output_str = '({} - {})'.format(graph[self._inputs[0]].output_str, graph[self._inputs[1]].output_str)
+        self._output_str = f'({graph[self._inputs[0]].output_str} - {graph[self._inputs[1]].output_str})'
 
 
 class CGPMul(CGPNode):
@@ -189,7 +189,7 @@ class CGPMul(CGPNode):
         self._output = graph[self._inputs[0]].output * graph[self._inputs[1]].output
 
     def format_output_str(self, graph):
-        self._output_str = '({} * {})'.format(graph[self._inputs[0]].output_str, graph[self._inputs[1]].output_str)
+        self._output_str = f'({graph[self._inputs[0]].output_str} * {graph[self._inputs[1]].output_str})'
 
 
 class CGPDiv(CGPNode):
@@ -205,8 +205,7 @@ class CGPDiv(CGPNode):
         self._output = graph[self._inputs[0]].output / graph[self._inputs[1]].output
 
     def format_output_str(self, graph):
-        self._output_str = '({inp0} / {inp1})'.format(
-            inp0=graph[self._inputs[0]].output_str, inp1=graph[self._inputs[1]].output_str)
+        self._output_str = f'({graph[self._inputs[0]].output_str} / {graph[self._inputs[1]].output_str})'
 
 
 class CGPConstantFloat(CGPNode):
@@ -224,13 +223,13 @@ class CGPConstantFloat(CGPNode):
         pass
 
     def format_output_str(self, graph):
-        self._output_str = '{}'.format(self._output)
+        self._output_str = f'{self._output}'
 
     def format_output_str_torch(self, graph):
-        self._output_str = 'self._p{}.expand(x.shape[0])'.format(self._idx)
+        self._output_str = f'self._p{self._idx}.expand(x.shape[0])'
 
     def format_parameter_str(self):
-        self._parameter_str = 'self._p{} = torch.nn.Parameter(torch.Tensor([{}]))\n'.format(self._idx, self._output)
+        self._parameter_str = f'self._p{self._idx} = torch.nn.Parameter(torch.Tensor([{self._output}]))\n'
 
 
 def custom_cgp_constant_float(val):
@@ -261,10 +260,10 @@ class CGPInputNode(CGPNode):
         assert(False)
 
     def format_output_str(self, graph):
-        self._output_str = 'x[{}]'.format(self._idx)
+        self._output_str = f'x[{self._idx}]'
 
     def format_output_str_torch(self, graph):
-        self._output_str = 'x[:, {}]'.format(self._idx)
+        self._output_str = f'x[:, {self._idx}]'
 
 
 class CGPOutputNode(CGPNode):
@@ -279,7 +278,7 @@ class CGPOutputNode(CGPNode):
         self._output = graph[self._inputs[0]].output
 
     def format_output_str(self, graph):
-        self._output_str = '{}'.format(graph[self._inputs[0]].output_str)
+        self._output_str = f'{graph[self._inputs[0]].output_str}'
 
 
 class CGPPow(CGPNode):
@@ -294,4 +293,4 @@ class CGPPow(CGPNode):
         self._output = graph[self._inputs[0]].output ** graph[self._inputs[1]].output
 
     def format_output_str(self, graph):
-        self._output_str = '({} ** {})'.format(graph[self._inputs[0]].output_str, graph[self._inputs[1]].output_str)
+        self._output_str = f'({graph[self._inputs[0]].output_str} ** {graph[self._inputs[1]].output_str})'


### PR DESCRIPTION
As the PR title says: it simply replaces all formatted strings by f-strings, which is the more modern and readable syntax.

Fixes #21 .