### PR TITLE
Replace record_history with callback

### DIFF
--- a/examples/example_evo_regression.py
+++ b/examples/example_evo_regression.py
@@ -96,24 +96,24 @@ def evolution(f_target):
     # create instance of evolutionary algorithm
     ea = gp.ea.MuPlusLambda(**params["ea_params"])
 
-    def record_history(pop, history):
-        keys = ["champion", "fitness_parents"]
-        for key in keys:
-            if key not in history:
-                history[key] = []
+    history = {}
+    history["champion"] = []
+    history["fitness_parents"] = []
+
+    def recording_callback(pop):
         history["champion"].append(pop.champion)
         history["fitness_parents"].append(pop.fitness_parents())
 
     obj = functools.partial(objective, target_function=f_target)
     # Perform evolution
-    history = gp.evolve(
+    gp.evolve(
         pop,
         obj,
         ea,
         params["max_generations"],
         params["min_fitness"],
-        record_history=record_history,
         print_progress=True,
+        callback=recording_callback,
     )
     return history, pop
 

--- a/gp/hl_api.py
+++ b/gp/hl_api.py
@@ -7,9 +7,9 @@ def evolve(
     ea,
     max_generations,
     min_fitness,
-    record_history=None,
     print_progress=False,
     *,
+    callback=None,
     label=None,
     n_processes=1,
 ):
@@ -31,11 +31,11 @@ def evolve(
         Maximum number of generations.
     min_fitness : float
         Minimum fitness at which the evolution is stopped.
-    record_history :  callable
-        Function that accepts a population instance and a dictionary
-        and records properties of interest in the dictionary. Defaults to None.
     print_progress : boolean, optional
         Switch to print out the progress of the algorithm. Defaults to False.
+    callback :  callable, optional
+        Called after each iteration with the population instance.
+        Defaults to None.
     label : str, optional
         Optional label to be passed to the objective function.
     n_processes : int, optional
@@ -49,13 +49,9 @@ def evolve(
         History of the evolution.
     """
 
-    # data structure for recording evolution history; can be populated via user
-    # defined recording function
-    history = {}
-
     ea.initialize_fitness_parents(pop, objective, label=label)
-    if record_history is not None:
-        record_history(pop, history)
+    if callback is not None:
+        callback(pop)
 
     # perform evolution
     max_fitness = np.finfo(np.float).min
@@ -77,15 +73,11 @@ def evolve(
                 end="",
             )
 
-        if record_history is not None:
-            record_history(pop, history)
+        if callback is not None:
+            callback(pop)
 
         if pop.champion.fitness + 1e-10 >= min_fitness:
-            for key in history:
-                history[key] = history[key][: pop.generation + 1]
             break
 
     if print_progress:
         print()
-
-    return history

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -66,28 +66,25 @@ def test_history_recording():
         population_params["tournament_size"],
     )
 
-    def record_history(pop, history):
-        if "fitness" not in history:
-            history["fitness"] = np.empty(
-                (population_params["max_generations"], population_params["n_parents"])
-            )
+    history = {}
+    history["fitness"] = np.empty(
+        (population_params["max_generations"], population_params["n_parents"])
+    )
+    history["fitness_champion"] = np.empty(population_params["max_generations"])
+    history["expr_champion"] = []
+
+    def recording_callback(pop):
         history["fitness"][pop.generation] = pop.fitness_parents()
-
-        if "fitness_champion" not in history:
-            history["fitness_champion"] = np.empty(population_params["max_generations"])
         history["fitness_champion"][pop.generation] = pop.champion.fitness
-
-        if "expr_champion" not in history:
-            history["expr_champion"] = []
         history["expr_champion"].append(str(pop.champion.to_sympy(simplify=True)[0]))
 
-    history = gp.evolve(
+    gp.evolve(
         pop,
         objective_history_recording,
         ea,
         population_params["max_generations"],
         population_params["min_fitness"],
-        record_history=record_history,
+        callback=recording_callback,
     )
 
     assert np.all(history["fitness"] == pytest.approx(1.0))


### PR DESCRIPTION
Only providing a callback provides more flexibility and is cleaner to implement.

closes #8 