### PR TITLE
Update of parameters from torch class: Call item() to detach() tensor…

### DIFF
--- a/gp/cartesian_graph.py
+++ b/gp/cartesian_graph.py
@@ -287,7 +287,7 @@ class _C(torch.nn.Module):
         for n in self._nodes:
             if n.is_parameter:
                 try:
-                    n._output = eval(f"torch_cls._p{n._idx}[0]")
+                    n._output = eval(f"torch_cls._p{n._idx}[0].item()")
                 except AttributeError:
                     pass
 


### PR DESCRIPTION
Fix bug discussed in #72 : When updating the value of a constant node from the parameters of a `torch` class, we need to call `item()` to detach the tensor and receive a Python number.