### PR TITLE
Enh/to numpy

### DIFF
--- a/gp/cartesian_graph.py
+++ b/gp/cartesian_graph.py
@@ -205,7 +205,7 @@ class CartesianGraph:
                 node.format_output_str(self)
 
     def to_func(self):
-        """Compile the function represented by the computational graph.
+        """Compile the function(s) represented by the graph.
 
         Generates a definition of the function in Python code and
         executes the function definition to create a Callable.
@@ -213,7 +213,7 @@ class CartesianGraph:
         Returns
         -------
         Callable
-            Callable executing the function represented by the computational graph.
+            Callable executing the function(s) represented by the graph.
         """
         self._format_output_str_of_all_nodes()
         s = ", ".join(node.output_str for node in self.output_nodes)
@@ -271,7 +271,7 @@ def _f(x):
         return locals()["_f"]
 
     def to_torch(self):
-        """Compile the function represented by the computational graph to a Torch class.
+        """Compile the function(s) represented by the graph to a Torch class.
 
         Generates a definition of the Torch class in Python code and
         executes it to create an instance of the class.
@@ -348,20 +348,20 @@ class _C(torch.nn.Module):
                     pass
 
     def to_sympy(self, simplify=True):
-        """Compile computational graph into a list of sympy-compatible string expressions.
+        """Compile the function(s) represented by the graph to a SymPy expression.
 
-        Generates one sympy expression for each output node.
+        Generates one SymPy expression for each output node.
 
         Parameters
         ----------
         simplify : boolean, optional
-            Whether to simplify the expression using sympy's
+            Whether to simplify the expression using SymPy's
             simplify() method. Defaults to True.
 
         Returns
         ----------
         List[sympy.core.Expr]
-            List of sympy expressions.
+            List of SymPy expressions.
         """
         if sympy is None:
             raise ModuleNotFoundError("No module named 'sympy' (extra requirement)")

--- a/gp/individual.py
+++ b/gp/individual.py
@@ -102,6 +102,16 @@ class Individual:
         """
         return CartesianGraph(self.genome).to_func()
 
+    def to_numpy(self):
+        """Return the expression represented by the individual as
+        NumPy-compatible Callable.
+
+        Returns
+        -------
+        Callable
+        """
+        return CartesianGraph(self.genome).to_numpy()
+
     def to_torch(self):
         """Return the expression represented by the individual as Torch class.
 

--- a/gp/node.py
+++ b/gp/node.py
@@ -124,6 +124,14 @@ class Node:
         """
         raise NotImplementedError()
 
+    def format_output_str_numpy(self, graph):
+        """Format output string for NumPy representation.
+
+        If format_output_str_numpy implementation is not provided, use
+        standard output_str.
+        """
+        self.format_output_str(graph)
+
     def format_output_str_torch(self, graph):
         """Format output string for torch representation.
 
@@ -243,6 +251,9 @@ class ConstantFloat(Node):
     def format_output_str(self, graph):
         self._output_str = f"{self._output}"
 
+    def format_output_str_numpy(self, graph):
+        self._output_str = f"np.ones(x.shape[0]) * {self._output}"
+
     def format_output_str_torch(self, graph):
         self._output_str = f"self._p{self._idx}.expand(x.shape[0])"
 
@@ -266,6 +277,9 @@ class InputNode(Node):
 
     def format_output_str(self, graph):
         self._output_str = f"x[{self._idx}]"
+
+    def format_output_str_numpy(self, graph):
+        self._output_str = f"x[:, {self._idx}]"
 
     def format_output_str_torch(self, graph):
         self._output_str = f"x[:, {self._idx}]"

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -132,6 +132,21 @@ def test_compile_addsubmul():
     assert (x[0] * x[1]) - (x[0] - x[1]) == pytest.approx(y[0])
 
 
+def test_to_numpy():
+    primitives = [gp.Add, gp.Mul, gp.ConstantFloat]
+    genome = gp.Genome(1, 1, 2, 2, 1, primitives)
+    # f(x) = x ** 2 + 1.
+    genome.dna = [-1, None, None, 2, None, None, 1, 0, 0, 0, 1, 2, 0, 0, 1, -2, 3, None]
+    graph = gp.CartesianGraph(genome)
+    f = graph.to_numpy()
+
+    x = np.random.normal(size=(100, 1))
+    y = f(x)
+    y_target = x ** 2 + 1.0
+
+    assert y == pytest.approx(y_target)
+
+
 def test_to_torch_and_backprop():
     torch = pytest.importorskip("torch")
 
@@ -226,6 +241,15 @@ genomes[3].dna = [
 
 
 @pytest.mark.parametrize("genome, batch_size", itertools.product(genomes, batch_sizes))
+def test_compile_numpy_output_shape(genome, batch_size):
+
+    c = gp.CartesianGraph(genome).to_numpy()
+    x = np.random.normal(size=(batch_size, 1))
+    y = c(x)
+    assert y.shape == (batch_size, genome._n_outputs)
+
+
+@pytest.mark.parametrize("genome, batch_size", itertools.product(genomes, batch_sizes))
 def test_compile_torch_output_shape(genome, batch_size):
     torch = pytest.importorskip("torch")
 
@@ -299,6 +323,29 @@ def test_input_dim_python():
 
     # do not fail for input with correct length
     f([None, None])
+
+
+def test_input_dim_numpy():
+    rng = np.random.RandomState(SEED)
+
+    genome = gp.Genome(2, 1, 1, 1, 1, [gp.ConstantFloat])
+    genome.randomize(rng)
+    f = gp.CartesianGraph(genome).to_numpy()
+
+    # fail for missing batch dimension
+    with pytest.raises(ValueError):
+        f(np.array([1.0]))
+
+    # fail for too short input
+    with pytest.raises(ValueError):
+        f(np.array([1.0]).reshape(-1, 1))
+
+    # fail for too long input
+    with pytest.raises(ValueError):
+        f(np.array([1.0, 1.0, 1.0]).reshape(-1, 3))
+
+    # do not fail for input with correct shape
+    f(np.array([1.0, 1.0]).reshape(-1, 2))
 
 
 def test_input_dim_torch():


### PR DESCRIPTION
support `to_numpy` compilation by replacing `x[0]` with `x[:, 0]` etc in regular output string of compiled expression. assumes that inputs are numpy arrays with structure `(batch_size, input_size)`. what do you think of this torch-style convention with regards to numpy arrays @mschmidt87 ?

fixes #56 