### PR TITLE
Remove unnecessary `output_str_torch` property

### DIFF
--- a/gp/cartesian_graph.py
+++ b/gp/cartesian_graph.py
@@ -250,7 +250,7 @@ def _f(x):
                 if node.is_parameter:
                     node.format_parameter_str()
                     all_parameter_str.append(node.parameter_str)
-        forward_str = ", ".join(node.output_str_torch for node in self.output_nodes)
+        forward_str = ", ".join(node.output_str for node in self.output_nodes)
         class_str = f"""\
 class _C(torch.nn.Module):
 

--- a/gp/node.py
+++ b/gp/node.py
@@ -127,7 +127,7 @@ class Node:
     def format_output_str_torch(self, graph):
         """Format output string for torch representation.
 
-        If output_str_torch implementation is not provided, use
+        If format_output_str_torch implementation is not provided, use
         standard output_str.
         """
         self.format_output_str(graph)
@@ -138,10 +138,6 @@ class Node:
     @property
     def output_str(self):
         return self._output_str
-
-    @property
-    def output_str_torch(self):
-        return self.output_str
 
     @property
     def is_parameter(self):

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -229,8 +229,7 @@ genomes[3].dna = [
 def test_compile_torch_output_shape(genome, batch_size):
     torch = pytest.importorskip("torch")
 
-    graph = gp.CartesianGraph(genome)
-    c = graph.to_torch()
+    c = gp.CartesianGraph(genome).to_torch()
     x = torch.Tensor(batch_size, 1).normal_()
     y = c(x)
     assert y.shape == (batch_size, genome._n_outputs)


### PR DESCRIPTION
This does not seem to be used anywhere and is unnecessary in the first place: the `format_output_str...` functions  all modify the `_output_str` member prior to generating the full expression. Can be re-added if the need arises.