### PR TITLE
Use fixed rng seed for tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,4 @@
 import gp
-import numpy as np
 from pytest import fixture
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,7 @@ from pytest import fixture
 
 @fixture
 def rng_seed():
-    return np.random.randint(2 ** 31)
+    return 1234
 
 
 @fixture
@@ -23,6 +23,11 @@ def genome_params():
 @fixture
 def population_params(mutation_rate, rng_seed):
     return {"n_parents": 5, "mutation_rate": mutation_rate, "seed": rng_seed}
+
+
+@fixture
+def ea_params():
+    return {"n_offsprings": 5, "n_breeding": 5, "tournament_size": 2}
 
 
 @fixture

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -5,9 +5,6 @@ import pytest
 import gp
 
 
-SEED = np.random.randint(2 ** 31)
-
-
 def test_direct_input_output():
     params = {"n_inputs": 1, "n_outputs": 1, "n_columns": 3, "n_rows": 3, "levels_back": 2}
     primitives = [gp.Add, gp.Sub]
@@ -305,8 +302,8 @@ def test_allow_powers_of_x_0():
     graph.to_sympy(simplify=True)
 
 
-def test_input_dim_python():
-    rng = np.random.RandomState(SEED)
+def test_input_dim_python(rng_seed):
+    rng = np.random.RandomState(rng_seed)
 
     genome = gp.Genome(2, 1, 1, 1, 1, [gp.ConstantFloat])
     genome.randomize(rng)
@@ -324,8 +321,8 @@ def test_input_dim_python():
     f([None, None])
 
 
-def test_input_dim_numpy():
-    rng = np.random.RandomState(SEED)
+def test_input_dim_numpy(rng_seed):
+    rng = np.random.RandomState(rng_seed)
 
     genome = gp.Genome(2, 1, 1, 1, 1, [gp.ConstantFloat])
     genome.randomize(rng)
@@ -347,10 +344,10 @@ def test_input_dim_numpy():
     f(np.array([1.0, 1.0]).reshape(-1, 2))
 
 
-def test_input_dim_torch():
+def test_input_dim_torch(rng_seed):
     torch = pytest.importorskip("torch")
 
-    rng = np.random.RandomState(SEED)
+    rng = np.random.RandomState(rng_seed)
 
     genome = gp.Genome(2, 1, 1, 1, 1, [gp.ConstantFloat])
     genome.randomize(rng)

--- a/test/test_ea_mu_plus_lambda.py
+++ b/test/test_ea_mu_plus_lambda.py
@@ -3,25 +3,7 @@ import numpy as np
 import gp
 
 
-SEED = np.random.randint(2 ** 31)
-
-population_params = {
-    "n_parents": 5,
-    "mutation_rate": 0.05,
-    "seed": SEED,
-}
-
-genome_params = {
-    "n_inputs": 2,
-    "n_outputs": 1,
-    "n_columns": 3,
-    "n_rows": 3,
-    "levels_back": 2,
-    "primitives": [gp.Add, gp.Sub, gp.Mul, gp.ConstantFloat],
-}
-
-
-def test_label():
+def test_label(population_params, genome_params):
     def objective_without_label(individual):
         assert True
         individual.fitness = -1
@@ -40,7 +22,7 @@ def test_label():
     ea.step(pop, objective_with_label, label="test")
 
 
-def test_fitness_contains_nan():
+def test_fitness_contains_nan(population_params, genome_params):
     def objective(individual):
         if np.random.rand() < 0.5:
             individual.fitness = np.nan

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -4,9 +4,6 @@ import pytest
 import gp
 
 
-SEED = np.random.randint(2 ** 31)
-
-
 def test_check_dna_consistency():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
 
@@ -166,7 +163,7 @@ def test_catch_no_non_coding_allele_in_non_coding_region():
     genome.dna = [-1, None, 0, None, -2, 1]
 
 
-def test_individuals_have_different_genomes():
+def test_individuals_have_different_genomes(rng_seed):
 
     population_params = {
         "n_parents": 5,
@@ -191,7 +188,7 @@ def test_individuals_have_different_genomes():
         return ind
 
     pop = gp.Population(
-        population_params["n_parents"], population_params["mutation_rate"], SEED, genome_params
+        population_params["n_parents"], population_params["mutation_rate"], rng_seed, genome_params
     )
     ea = gp.ea.MuPlusLambda(
         population_params["n_offspring"],

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pickle
 
 import gp

--- a/test/test_individual.py
+++ b/test/test_individual.py
@@ -5,9 +5,6 @@ import gp
 from gp.individual import Individual
 
 
-SEED = np.random.randint(2 ** 31)
-
-
 def test_pickle_individual():
 
     primitives = [gp.Add]

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -4,9 +4,6 @@ import pytest
 import gp
 
 
-SEED = np.random.randint(2 ** 31)
-
-
 def test_add():
     params = {"n_inputs": 2, "n_outputs": 1, "n_columns": 1, "n_rows": 1, "levels_back": 1}
 

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 import gp

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -5,9 +5,6 @@ import gp
 from gp.primitives import Primitives
 
 
-SEED = np.random.randint(2 ** 31)
-
-
 def test_immutable_primitives():
     primitives = Primitives([gp.Add, gp.Sub])
     with pytest.raises(TypeError):

--- a/test/test_primitives.py
+++ b/test/test_primitives.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 import gp

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,9 +6,6 @@ import time
 import gp
 
 
-SEED = np.random.randint(2 ** 31)
-
-
 def test_cache_decorator():
 
     sleep_time = 0.1
@@ -84,41 +81,21 @@ def objective_history_recording(individual):
     return individual
 
 
-def test_history_recording():
+def test_history_recording(population_params, genome_params, ea_params):
 
-    population_params = {
-        "n_parents": 4,
-        "n_offsprings": 4,
+    pop = gp.Population(**population_params, genome_params=genome_params)
+    ea = gp.ea.MuPlusLambda(**ea_params)
+
+    evolve_params = {
         "max_generations": 2,
-        "n_breeding": 5,
-        "tournament_size": 2,
-        "mutation_rate": 0.05,
-        "min_fitness": 2.0,
+        "min_fitness": 1.0,
     }
-
-    genome_params = {
-        "n_inputs": 2,
-        "n_outputs": 1,
-        "n_columns": 3,
-        "n_rows": 3,
-        "levels_back": 2,
-        "primitives": [gp.Add, gp.Sub, gp.Mul, gp.ConstantFloat],
-    }
-
-    pop = gp.Population(
-        population_params["n_parents"], population_params["mutation_rate"], SEED, genome_params
-    )
-    ea = gp.ea.MuPlusLambda(
-        population_params["n_offsprings"],
-        population_params["n_breeding"],
-        population_params["tournament_size"],
-    )
 
     history = {}
     history["fitness"] = np.empty(
-        (population_params["max_generations"], population_params["n_parents"])
+        (evolve_params["max_generations"], population_params["n_parents"])
     )
-    history["fitness_champion"] = np.empty(population_params["max_generations"])
+    history["fitness_champion"] = np.empty(evolve_params["max_generations"])
     history["champion"] = []
 
     def recording_callback(pop):
@@ -127,12 +104,7 @@ def test_history_recording():
         history["champion"].append(pop.champion)
 
     gp.evolve(
-        pop,
-        objective_history_recording,
-        ea,
-        population_params["max_generations"],
-        population_params["min_fitness"],
-        callback=recording_callback,
+        pop, objective_history_recording, ea, **evolve_params, callback=recording_callback,
     )
 
     assert np.all(history["fitness"] == pytest.approx(1.0))


### PR DESCRIPTION
as the title suggests, this PR replaces the stochastic random seed with a fixed random seed from `conftest` in all tests. it also uses a few more fixtures where appropriate.

this should avoid the random failures of tests possibly responsible for #75 