### PR TITLE
Maint/remove non coding allele

### DIFF
--- a/gp/cartesian_graph.py
+++ b/gp/cartesian_graph.py
@@ -160,8 +160,7 @@ class CartesianGraph:
             active_nodes_by_hidden_column_idx[self._hidden_column_idx(node.idx)].add(node)
 
             for i in node.inputs:
-                if i is not self._genome._non_coding_allele:
-                    nodes_to_process.append(self._nodes[i])
+                nodes_to_process.append(self._nodes[i])
 
         return active_nodes_by_hidden_column_idx
 

--- a/gp/genome.py
+++ b/gp/genome.py
@@ -271,6 +271,17 @@ class Genome:
             ]
             yield region_idx, region
 
+    def _is_gene_in_input_region(self, gene_idx):
+        return gene_idx < (self._n_inputs * self._length_per_region)
+
+    def _is_gene_in_hidden_region(self, gene_idx):
+        return ((self._n_inputs * self._length_per_region) <= gene_idx) & (
+            gene_idx < ((self._n_inputs + self._n_hidden) * self._length_per_region)
+        )
+
+    def _is_gene_in_output_region(self, gene_idx):
+        return ((self._n_inputs + self._n_hidden) * self._length_per_region) <= gene_idx
+
     def _is_input_region(self, region_idx):
         return region_idx < self._n_inputs
 

--- a/gp/node.py
+++ b/gp/node.py
@@ -40,7 +40,7 @@ class Node:
             List of integers specifying the input nodes to this node.
         """
         self._idx = idx
-        self._inputs = inputs
+        self._inputs = inputs[: self._arity]
 
         assert idx not in inputs
 
@@ -58,7 +58,7 @@ class Node:
 
     @property
     def inputs(self):
-        return self._inputs[: self._arity]
+        return self._inputs
 
     @property
     def idx(self):

--- a/gp/primitives.py
+++ b/gp/primitives.py
@@ -5,7 +5,6 @@ class Primitives:
     """Class collecting primitives of the Cartesian Genetic Programming framework.
     """
 
-    _n_primitives = 0
     _max_arity = 0
     _primitives = None
 
@@ -22,8 +21,6 @@ class Primitives:
                 raise TypeError(f"expected class but received {type(primitives[i])}")
             if not issubclass(primitives[i], Node):
                 raise TypeError(f"expected subclass of Node but received {primitives[i].__name__}")
-
-        self._n_primitives = len(primitives)
 
         self._primitives = {}
         for i in range(len(primitives)):

--- a/test/test_cartesian_graph.py
+++ b/test/test_cartesian_graph.py
@@ -133,7 +133,7 @@ def test_to_numpy():
     primitives = [gp.Add, gp.Mul, gp.ConstantFloat]
     genome = gp.Genome(1, 1, 2, 2, 1, primitives)
     # f(x) = x ** 2 + 1.
-    genome.dna = [-1, None, None, 2, None, None, 1, 0, 0, 0, 1, 2, 0, 0, 1, -2, 3, None]
+    genome.dna = [-1, None, None, 2, 0, 0, 1, 0, 0, 0, 1, 2, 0, 0, 1, -2, 3, None]
     graph = gp.CartesianGraph(genome)
     f = graph.to_numpy()
 
@@ -149,7 +149,7 @@ def test_to_torch_and_backprop():
 
     primitives = [gp.Mul, gp.ConstantFloat]
     genome = gp.Genome(1, 1, 2, 2, 1, primitives)
-    genome.dna = [-1, None, None, 1, None, None, 1, None, None, 0, 0, 1, 0, 0, 1, -2, 3, None]
+    genome.dna = [-1, None, None, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, -2, 3, None]
     graph = gp.CartesianGraph(genome)
 
     c = graph.to_torch()
@@ -182,9 +182,9 @@ batch_sizes = [1, 10]
 primitives = [gp.Mul, gp.ConstantFloat]
 genomes = [gp.Genome(1, 1, 2, 2, 1, primitives) for i in range(2)]
 # Function: f(x) = 1*x
-genomes[0].dna = [-1, None, None, 1, None, None, 1, None, None, 0, 0, 1, 0, 0, 1, -2, 3, None]
+genomes[0].dna = [-1, None, None, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, -2, 3, None]
 # Function: f(x) = 1
-genomes[1].dna = [-1, None, None, 1, None, None, 1, None, None, 0, 0, 1, 0, 0, 1, -2, 1, None]
+genomes[1].dna = [-1, None, None, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, -2, 1, None]
 
 genomes += [gp.Genome(1, 2, 2, 2, 1, primitives) for i in range(2)]
 # Function: f(x) = (1*x, 1*1)
@@ -193,11 +193,11 @@ genomes[2].dna = [
     None,
     None,
     1,
-    None,
-    None,
+    0,
+    0,
     1,
-    None,
-    None,
+    0,
+    0,
     0,
     0,
     1,
@@ -217,11 +217,11 @@ genomes[3].dna = [
     None,
     None,
     1,
-    None,
-    None,
+    0,
+    0,
     1,
-    None,
-    None,
+    0,
+    0,
     0,
     1,
     1,
@@ -262,7 +262,7 @@ def test_to_sympy():
     primitives = [gp.Add, gp.ConstantFloat]
     genome = gp.Genome(1, 1, 2, 2, 1, primitives)
 
-    genome.dna = [-1, None, None, 1, None, None, 1, None, None, 0, 0, 1, 0, 0, 1, -2, 3, None]
+    genome.dna = [-1, None, None, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, -2, 3, None]
     graph = gp.CartesianGraph(genome)
 
     x_0_target, y_0_target = sympy.symbols("x_0_target y_0_target")

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -150,17 +150,17 @@ def test_check_levels_back_consistency():
     )
 
 
-def test_catch_no_non_coding_allele_in_non_coding_region():
+def test_catch_invalid_allele_in_non_coding_region():
     primitives = [gp.ConstantFloat]
     genome = gp.Genome(1, 1, 1, 1, 1, primitives)
 
-    # should raise error: ConstantFloat node has no inputs, but input gene has
-    # value different from the non-coding allele
+    # should raise error: ConstantFloat node has no inputs, but silent
+    # input gene should still specify valid input
     with pytest.raises(ValueError):
-        genome.dna = [-1, None, 0, 0, -2, 1]
+        genome.dna = [-1, None, 0, None, -2, 1]
 
     # correct
-    genome.dna = [-1, None, 0, None, -2, 1]
+    genome.dna = [-1, None, 0, 0, -2, 1]
 
 
 def test_individuals_have_different_genomes(rng_seed):

--- a/test/test_genome.py
+++ b/test/test_genome.py
@@ -209,3 +209,32 @@ def test_individuals_have_different_genomes(rng_seed):
                 assert parent_i is not parent_j
                 assert parent_i.genome is not parent_j.genome
                 assert parent_i.genome.dna is not parent_j.genome.dna
+
+
+def test_is_gene_in_input_region(rng_seed):
+    genome = gp.Genome(2, 1, 2, 1, None, [gp.Add])
+    rng = np.random.RandomState(rng_seed)
+    genome.randomize(rng)
+
+    assert genome._is_gene_in_input_region(0)
+    assert not genome._is_gene_in_input_region(6)
+
+
+def test_is_gene_in_hidden_region(rng_seed):
+    genome = gp.Genome(2, 1, 2, 1, None, [gp.Add])
+    rng = np.random.RandomState(rng_seed)
+    genome.randomize(rng)
+
+    assert genome._is_gene_in_hidden_region(6)
+    assert genome._is_gene_in_hidden_region(9)
+    assert not genome._is_gene_in_hidden_region(5)
+    assert not genome._is_gene_in_hidden_region(12)
+
+
+def test_is_gene_in_output_region(rng_seed):
+    genome = gp.Genome(2, 1, 2, 1, None, [gp.Add])
+    rng = np.random.RandomState(rng_seed)
+    genome.randomize(rng)
+
+    assert genome._is_gene_in_output_region(12)
+    assert not genome._is_gene_in_output_region(11)

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -120,7 +120,7 @@ def test_constant_float():
         params["levels_back"],
         primitives,
     )
-    genome.dna = [-1, None, -1, None, 0, None, -2, 2]
+    genome.dna = [-1, None, -1, None, 0, 0, -2, 2]
     graph = gp.CartesianGraph(genome)
 
     x = [None, None]

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -128,3 +128,22 @@ def test_constant_float():
 
     # by default the output value of the ConstantFloat node is 1.0
     assert 1.0 == pytest.approx(y[0])
+
+
+def test_inputs_are_cut_to_match_arity():
+    """Test that even if a list of inputs longer than the node arity is
+    provided, Node.inputs only returns the initial <arity> inputs,
+    ignoring the inactive genes.
+
+    """
+    idx = 0
+    inputs = [1, 2, 3, 4]
+
+    node = gp.ConstantFloat(idx, inputs)
+    assert node.inputs == []
+
+    node = gp.node.OutputNode(idx, inputs)
+    assert node.inputs == inputs[:1]
+
+    node = gp.Add(idx, inputs)
+    assert node.inputs == inputs[:2]

--- a/test/test_node_factories.py
+++ b/test/test_node_factories.py
@@ -17,7 +17,7 @@ def test_constant_float():
         params["levels_back"],
         primitives,
     )
-    genome.dna = [-1, None, -1, None, 0, None, -2, 2]
+    genome.dna = [-1, None, -1, None, 0, 0, -2, 2]
     graph = gp.CartesianGraph(genome)
 
     x = [None, None]


### PR DESCRIPTION
Following up on #37, this PR removes the concept of a "non-coding allele". Previously this was used to indicate which parts of the genome are currently in use, since some nodes, e.g., with arity=0, have superfluous "non-coding" genes coding for their inputs. As discussed these regions of the genome should also be subject to mutation.
The `mutate` function now can modify any part of the genome, except never-used genes of the input and output nodes. The check for silent mutations now correctly determines whether changing an input gene will change the output of the graph, e.g., changing any input gene on a ConstantFloat node is considered a silent mutation.

closes #37 